### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/StationScience/StationScience.version
+++ b/GameData/StationScience/StationScience.version
@@ -1,26 +1,26 @@
 {
-  "NAME":"StationScienceContinued",
-	 "URL":"https://github.com/linuxgurugamer/StationScience/blob/master/Kerbal%20Space%20Program/GameData/StationScience/StationScience.version",
-	 "DOWNLOAD":"https://github.com/linuxgurugamer/StationScience/releases",
-  "GITHUB": {
-    "USERNAME": "linuxgurugamer",
-    "REPOSITORY": "StationScience",
-    "ALLOW_PRE_RELEASE": false
-  },
-     "VERSION":{
-         "MAJOR":2,
-         "MINOR":6,
-         "PATCH":0,
-         "BUILD":1
+    "NAME": "StationScienceContinued",
+    "URL": "https://github.com/linuxgurugamer/StationScience/raw/master/GameData/StationScience/StationScience.version",
+    "DOWNLOAD": "https://github.com/linuxgurugamer/StationScience/releases",
+    "GITHUB": {
+        "USERNAME": "linuxgurugamer",
+        "REPOSITORY": "StationScience",
+        "ALLOW_PRE_RELEASE": false
+    },
+     "VERSION": {
+         "MAJOR": 2,
+         "MINOR": 6,
+         "PATCH": 0,
+         "BUILD": 1
      },
-     "KSP_VERSION":{
-         "MAJOR":1,
-         "MINOR":8,
-         "PATCH":1
+     "KSP_VERSION": {
+         "MAJOR": 1,
+         "MINOR": 8,
+         "PATCH": 1
      },
-     "KSP_VERSION_MIN":{
-         "MAJOR":1,
-         "MINOR":8,
-         "PATCH":0
+     "KSP_VERSION_MIN": {
+         "MAJOR": 1,
+         "MINOR": 8,
+         "PATCH": 0
      }
  }

--- a/StationScience.version
+++ b/StationScience.version
@@ -1,6 +1,6 @@
 {
   "NAME": "MOARStationScience",
-  "URL": "https://github.com/linuxgurugamer/StationScience/blob/master/Kerbal%20Space%20Program/GameData/StationScience/StationScience.version",
+  "URL": "https://github.com/linuxgurugamer/StationScience/raw/master/GameData/StationScience/StationScience.version",
   "DOWNLOAD": "https://github.com/linuxgurugamer/StationScience/releases",
   "GITHUB": {
     "USERNAME": "linuxgurugamer",


### PR DESCRIPTION
Hi @linuxgurugamer 

The remote version file is currently a 404 because there is no `Kerbal Space Program` folder in this repo. I suspect you'll want to use something from http://ksp.spacetux.net/, but until you figure that out this one will at least work.

Both copies of the version file in the repo are fixed.