### PR TITLE
Fix display errors and NREs

### DIFF
--- a/StationScience/StationExperiment.cs
+++ b/StationScience/StationExperiment.cs
@@ -424,7 +424,7 @@ namespace StationScience
                     ReadyToDeploy(false);
 #endif
                 ScienceExperiment experiment = ResearchAndDevelopment.GetExperiment(experimentID);
-                if (!experiment.IsAvailableWhile(GetScienceSituation(vessel), vessel.mainBody))
+                if (currentStatus == Status.Running && !experiment.IsAvailableWhile(GetScienceSituation(vessel), vessel.mainBody))
                 {
                     ScreenMessages.PostScreenMessage(Localizer.Format("Can't perform experiment here."), 6, ScreenMessageStyle.UPPER_CENTER);
                     currentStatus = Status.BadLocation;

--- a/StationScience/StationExperiment.cs
+++ b/StationScience/StationExperiment.cs
@@ -397,14 +397,6 @@ namespace StationScience
                         ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_StatSci_screen_detatch", part.partInfo.title), 2, ScreenMessageStyle.UPPER_CENTER);
                     }
                 }
-                if (numEurekas <= 0 || numKuarqs <=0)
-                {
-                    currentStatus = Status.Starved;
-                }
-                else
-                {
-                    currentStatus = Status.Running;
-                }
                 /*
                 if (numKuarqs > 0)
                 {

--- a/StationScience/StationExperiment.cs
+++ b/StationScience/StationExperiment.cs
@@ -87,7 +87,10 @@ namespace StationScience
 
         public static bool CheckBoring(Vessel vessel, bool msg = false)
         {
-            Log.Info(vessel.Landed + ", " + vessel.landedAt + ", " + vessel.launchTime + ", " + vessel.situation + ", " + vessel.orbit.referenceBody.name);
+	    if(null != Log)
+	    {
+	        Log.Info(vessel.Landed + ", " + vessel.landedAt + ", " + vessel.launchTime + ", " + vessel.situation + ", " + vessel.orbit.referenceBody.name);
+	    }
             if ((vessel.orbit.referenceBody == FlightGlobals.GetHomeBody()) && (vessel.situation == Vessel.Situations.LANDED || vessel.situation == Vessel.Situations.PRELAUNCH || vessel.situation == Vessel.Situations.SPLASHED || vessel.altitude <= vessel.orbit.referenceBody.atmosphereDepth))
             {
                 if (msg)


### PR DESCRIPTION
This fixes two display issues (experiments being perpetually listed as "Running", and a persistent "Can't perform experiment here" message when launching an experiment) and a NullReferenceException that occurs if StationExperiment.CheckBoring() is called before the "Log" variable is initialized (this can happen if the first thing you do after starting KSP is to switch to a vessel containing a laboratory module but not an experiment).