### PR TITLE
support for Dynamic Battery Storage mod

### DIFF
--- a/GameData/StationScience/Patches/MM-DBS.cfg
+++ b/GameData/StationScience/Patches/MM-DBS.cfg
@@ -1,0 +1,26 @@
+// Dynamic Battery Storage patch for MOAR Station Science
+//
+// author: Grimmas
+//
+
+
+@DYNAMICBATTERYSTORAGE:NEEDS[DynamicBatteryStorage,MOARStationScience]
+{
+	@HANDLERCATEGORY[Science]
+	{
+		module = StationScienceModule
+	}
+	
+	PARTMODULEHANDLER
+	{
+		name = StationScienceModule
+		type = Power
+		handlerModuleName = ModuleResourceConverterPowerHandler
+		visible = true
+		solarEfficiencyEffects = false
+		producer = false
+		consumer = true
+		simulated = true
+		continuous = false
+	}
+}


### PR DESCRIPTION
Affects electricity display in DBS only. Heat should be automatically handled as it's using the stock module - but that isn't the case.