### PR TITLE
Fix inability to remove obsolete experiments

### DIFF
--- a/GameData/StationScience/Patches/StationScience_CTT.cfg
+++ b/GameData/StationScience/Patches/StationScience_CTT.cfg
@@ -1,0 +1,6 @@
+@PART[costlyExperimentProgradeKuarqs]:NEEDS[CommunityTechTree]   { @TechRequired = largeElectrics }
+@PART[costlyExperimentRetrogradeKuarqs]:NEEDS[CommunityTechTree] { @TechRequired = specializedElectrics }
+@PART[costlyExperimentEccentricKuarqs]:NEEDS[CommunityTechTree]  { @TechRequired = experimentalElectrics }
+@PART[costlyExperimentCreatureComforts]:NEEDS[CommunityTechTree] { @TechRequired = shortTermHabitation }
+@PART[costlyExperimentKuarqBioactivity]:NEEDS[CommunityTechTree] { @TechRequired = longTermHabitation }
+@PART[costlyExperimentAdvancedFuels]:NEEDS[CommunityTechTree]    { @TechRequired = veryHeavyRocketry }

--- a/GameData/StationScience/Patches/StationScience_RSS.cfg
+++ b/GameData/StationScience/Patches/StationScience_RSS.cfg
@@ -1,0 +1,37 @@
+@STN_SCI_SETTINGS:AFTER[StationScience]:NEEDS[RealSolarSystem]
+{
+	@planetChallenge
+	{
+		// Copy values from similar stock planets
+		Earth =   #$../planetChallenge/Kerbin$
+		Moon =    #$../planetChallenge/Mun$
+		Mars =    #$../planetChallenge/Duna$
+		Deimos =  #$../planetChallenge/Gilly$
+		Phobos =  #$../planetChallenge/Ike$
+		Mercury = #$../planetChallenge/Dres$
+		Venus  =  #$../planetChallenge/Eve$
+		Ceres =   #$../planetChallenge/Minmus$
+		Vesta =   #$../planetChallenge/Minmus$
+		Jupiter = #$../planetChallenge/Jool$
+		Saturn =  #$../planetChallenge/Laythe$
+		Uranus =  #$../planetChallenge/Vall$
+		Neptune = #$../planetChallenge/Tylo$
+		Pluto =   #$../planetChallenge/Eeloo$
+
+		// Then remove stock planets
+		-Kerbin = delete
+		-Mun = delete
+		-Duna = delete
+		-Gilly = delete
+		-Ike = delete
+		-Dres = delete
+		-Eve = delete
+		-Minmus = delete
+		-Minmus = delete
+		-Jool = delete
+		-Laythe = delete
+		-Vall = delete
+		-Tylo = delete
+		-Eeloo = delete
+	}
+}

--- a/GameData/StationScience/Patches/StationScience_RSS.cfg
+++ b/GameData/StationScience/Patches/StationScience_RSS.cfg
@@ -32,6 +32,8 @@
 		-Laythe = delete
 		-Vall = delete
 		-Tylo = delete
+		-Pol = delete
+		-Bop = delete		
 		-Eeloo = delete
 	}
 }

--- a/GameData/StationScience/StationScience.cfg
+++ b/GameData/StationScience/StationScience.cfg
@@ -27,12 +27,15 @@ STN_SCI_SETTINGS
   // entry from these lists
   experimentChallenge
   {
-    StnSciExperiment1 = 1
-    StnSciExperiment2 = 2
-    StnSciExperiment3 = 2.5
-    StnSciExperiment4 = 3
-    StnSciExperiment5 = 2.5
-    StnSciExperiment6 = 3.5
+    costlyExperimentPlantGrowth = 1
+    costlyExperimentProgradeKuarqs = 2
+    costlyExperimentRetrogradeKuarqs = 2.5
+    costlyExperimentEccentricKuarqs = 3
+    costlyExperimentCreatureComforts = 2.5
+    costlyExperimentKuarqBioactivity = 3.5
+    costlyExperimentRocketFuels = 1.5
+    costlyExperimentAdvancedFuels = 2.75
+    costlyExperimentPlasmaFuels = 3.25
   }
 
   planetChallenge
@@ -71,12 +74,15 @@ STN_SCI_SETTINGS
   // These are for the ArcanumIndustries parts
   experimentPrereqs
   {
-    StnSciExperiment1 = costlyExperimentPlantGrowth,StnSciLab
-    StnSciExperiment2 = costlyExperimentProgradeKuarqs,StnSciCyclo
-    StnSciExperiment3 = costlyExperimentRetrogradeKuarqs,StnSciLab,StnSciCyclo
-    StnSciExperiment4 = costlyExperimentEccentricKuarqs,StnSciLab,StnSciCyclo
-    StnSciExperiment5 = costlyExperimentCreatureComforts,StnSciLab,StnSciZoo
-    StnSciExperiment6 = costlyExperimentKuarqBioactivity,StnSciLab,StnSciZoo,StnSciCyclo
+    costlyExperimentPlantGrowth = costlyExperimentPlantGrowth,StnSciLab
+    costlyExperimentProgradeKuarqs = costlyExperimentProgradeKuarqs,StnSciCyclo
+    costlyExperimentRetrogradeKuarqs = costlyExperimentRetrogradeKuarqs,StnSciLab,StnSciCyclo
+    costlyExperimentEccentricKuarqs = costlyExperimentEccentricKuarqs,StnSciLab,StnSciCyclo
+    costlyExperimentCreatureComforts = costlyExperimentCreatureComforts,StnSciLab,StnSciZoo
+    costlyExperimentKuarqBioactivity = costlyExperimentKuarqBioactivity,StnSciLab,StnSciZoo,StnSciCyclo
+    costlyExperimentRocketFuels = costlyExperimentRocketFuels,StnSciLab
+    costlyExperimentAdvancedFuels = costlyExperimentAdvancedFuels,StnSciLab,StnSciCyclo
+    costlyExperimentPlasmaFuels = costlyExperimentPlasmaFuels,StnSciLab,StnSciCyclo
   }
 
   // For each of the following, the quantity set for the contract is

--- a/StationScience/StnSciScenario.cs
+++ b/StationScience/StnSciScenario.cs
@@ -70,6 +70,7 @@ namespace StationScience
     {
         public void Load(ConfigNode node)
         {
+            Clear();
             foreach (ConfigNode.Value val in node.values)
             {
                 try
@@ -106,6 +107,7 @@ namespace StationScience
 
         public void Load(ConfigNode node)
         {
+            Clear();
             foreach (ConfigNode.Value val in node.values)
             {
                 if(!this.ContainsKey(val.name))


### PR DESCRIPTION
Clear dictionary before loading config nodes, otherwise default nodes cannot be removed.